### PR TITLE
feat: add points loading flow

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import LoginUser from './pages/LoginUser';
 import BrandSelect from './pages/BrandSelect';
 import Home from './pages/Home';
+import PointsStep1 from './pages/PointsStep1';
+import PointsStep2 from './pages/PointsStep2';
+import PointsStepFinal from './pages/PointsStepFinal';
 
 import PosSelect from './pages/PosSelect';
-import { Brand, Pos, mockFetchPos } from './api/mock';
+import { Brand, Pos, mockFetchPos, UserProfile } from './api/mock';
 
-type Screen = 'login1' | 'login2' | 'home' | 'pos';
+type Screen = 'login1' | 'login2' | 'home' | 'pos' | 'points1' | 'points2' | 'points3';
 
 
 declare global {
@@ -19,6 +22,9 @@ declare global {
 
 const App: React.FC = () => {
   const [screen, setScreen] = React.useState<Screen>('login1');
+  const [profile, setProfile] = React.useState<UserProfile | null>(null);
+  const [added, setAdded] = React.useState(0);
+  const [expires, setExpires] = React.useState('');
 
   React.useEffect(() => {
     const token = localStorage.getItem('token');
@@ -55,6 +61,7 @@ const App: React.FC = () => {
 
 
   const handleChangePos = () => setScreen('pos');
+  const handleStartPoints = () => setScreen('points1');
 
   const handleSelectPos = (pos: Pos) => {
     localStorage.setItem('pos', pos.name);
@@ -63,10 +70,45 @@ const App: React.FC = () => {
 
   const handleCancelPos = () => setScreen('home');
 
+  const handlePointsNext1 = (p: UserProfile) => {
+    setProfile(p);
+    setScreen('points2');
+  };
+  const handlePointsNext2 = (p: UserProfile, a: number, e: string) => {
+    setProfile(p);
+    setAdded(a);
+    setExpires(e);
+    setScreen('points3');
+  };
+  const handleBackPoints1 = () => setScreen('home');
+  const handleBackPoints2 = () => setScreen('points1');
+  const handleBackPoints3 = () => setScreen('points2');
+  const handleClosePoints = () => setScreen('home');
+
   if (screen === 'login1') return <LoginUser onLogin={handleLogged} />;
   if (screen === 'login2') return <BrandSelect onSelect={handleBrand} onLogout={handleLogout} />;
   if (screen === 'pos') return <PosSelect onSelect={handleSelectPos} onCancel={handleCancelPos} />;
-  return <Home onChangeBrand={handleChangeBrand} onLogout={handleLogout} onChangePos={handleChangePos} />;
+  if (screen === 'points1') return <PointsStep1 onBack={handleBackPoints1} onNext={handlePointsNext1} />;
+  if (screen === 'points2' && profile)
+    return <PointsStep2 profile={profile} onBack={handleBackPoints2} onNext={handlePointsNext2} />;
+  if (screen === 'points3' && profile)
+    return (
+      <PointsStepFinal
+        profile={profile}
+        added={added}
+        expires={expires}
+        onBack={handleBackPoints3}
+        onClose={handleClosePoints}
+      />
+    );
+  return (
+    <Home
+      onChangeBrand={handleChangeBrand}
+      onLogout={handleLogout}
+      onChangePos={handleChangePos}
+      onLoadPoints={handleStartPoints}
+    />
+  );
 
 };
 

--- a/src/renderer/api/mock.ts
+++ b/src/renderer/api/mock.ts
@@ -35,3 +35,52 @@ export async function mockFetchPos(brandId: string): Promise<Pos[]> {
   }));
 }
 
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  dni: string;
+  avatar?: string;
+  points: number;
+  level: string;
+  nextLevel: string;
+  pointsToNext: number;
+  totalRedeemed: number;
+  expiring?: { points: number; date: string };
+}
+
+let mockUser: UserProfile = {
+  id: '1',
+  name: 'Alejandro',
+  email: 'alejandro@example.com',
+  dni: '12345678',
+  points: 1200,
+  level: 'SILVER',
+  nextLevel: 'GOLD',
+  pointsToNext: 300,
+  totalRedeemed: 3400,
+  expiring: { points: 100, date: '2024-12-31' }
+};
+
+export async function mockFetchUser(dni: string, email: string): Promise<UserProfile> {
+  await new Promise(res => setTimeout(res, 500));
+  if (dni !== mockUser.dni || email !== mockUser.email) {
+    throw new Error('Usuario no registrado en el programa de puntos');
+  }
+  return mockUser;
+}
+
+export async function mockAddPoints(amount: number): Promise<{profile: UserProfile; added: number; expires: string}> {
+  await new Promise(res => setTimeout(res, 500));
+  const rate = 10;
+  const added = Math.floor(amount / rate);
+  mockUser.points += added;
+  mockUser.pointsToNext -= added;
+  if (mockUser.pointsToNext <= 0) {
+    mockUser.level = mockUser.nextLevel;
+    mockUser.nextLevel = 'PLATINUM';
+    mockUser.pointsToNext = 500;
+  }
+  return { profile: mockUser, added, expires: '2025-12-31' };
+}
+

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const Header: React.FC<Props> = ({ onChangeBrand, onLogout }) => {
   return (
-    <header className="flex justify-between items-center p-4">
+    <header className="flex justify-between items-center p-4 bg-white shadow">
       <div className="flex items-center text-2xl font-bold text-green-600">
         <span className="mr-2">★</span> AWER Reviews
       </div>

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface Props {
+  message: string;
+  type?: 'success' | 'error';
+}
+
+const Toast: React.FC<Props> = ({ message, type = 'success' }) => {
+  const bg = type === 'error' ? 'bg-red-500' : 'bg-green-500';
+  return (
+    <div className={`fixed bottom-4 right-4 px-4 py-2 text-white rounded shadow ${bg}`}>
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -6,9 +6,10 @@ interface Props {
   onLogout: () => void;
 
   onChangePos: () => void;
+  onLoadPoints: () => void;
 }
 
-const Home: React.FC<Props> = ({ onChangeBrand, onLogout, onChangePos }) => {
+const Home: React.FC<Props> = ({ onChangeBrand, onLogout, onChangePos, onLoadPoints }) => {
 
   const pos = localStorage.getItem('pos') || 'Punto de Venta';
 
@@ -17,7 +18,10 @@ const Home: React.FC<Props> = ({ onChangeBrand, onLogout, onChangePos }) => {
       <Header onChangeBrand={onChangeBrand} onLogout={onLogout} />
       <main className="flex flex-col items-center mt-20 gap-4">
         <h1 className="text-2xl font-semibold mb-4">{pos}</h1>
-        <button className="w-64 py-3 border border-green-500 rounded-full text-green-600 hover:bg-green-50">
+        <button
+          className="w-64 py-3 border border-green-500 rounded-full text-green-600 hover:bg-green-50"
+          onClick={onLoadPoints}
+        >
           Cargar puntos
         </button>
 

--- a/src/renderer/pages/PointsStep1.tsx
+++ b/src/renderer/pages/PointsStep1.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import Toast from '../components/Toast';
+import { mockFetchUser, UserProfile } from '../api/mock';
+
+interface Props {
+  onBack: () => void;
+  onNext: (profile: UserProfile) => void;
+}
+
+const PointsStep1: React.FC<Props> = ({ onBack, onNext }) => {
+  const [dni, setDni] = React.useState('');
+  const [email, setEmail] = React.useState('');
+  const [toast, setToast] = React.useState<string | null>(null);
+
+  const handleNext = () => {
+    mockFetchUser(dni, email)
+      .then(onNext)
+      .catch((e) => {
+        setToast(e.message);
+        setTimeout(() => setToast(null), 3000);
+      });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center relative">
+      <button onClick={onBack} className="absolute top-4 left-4 text-2xl">←</button>
+      <div className="bg-white p-8 rounded-xl shadow-md w-full max-w-md flex flex-col gap-4 items-center">
+        <div className="flex items-center text-2xl font-bold text-green-600">
+          <span className="mr-2">★</span> AWER Reviews
+        </div>
+        <h2 className="text-center">Cargue los datos del usuario</h2>
+        <input
+          type="text"
+          placeholder="DNI"
+          value={dni}
+          onChange={(e) => setDni(e.target.value)}
+          className="w-full px-3 py-2 border rounded"
+        />
+        <input
+          type="email"
+          placeholder="Correo"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full px-3 py-2 border rounded"
+        />
+        <button
+          onClick={handleNext}
+          className="w-full py-2 mt-2 border border-green-500 rounded-full text-green-600 hover:bg-green-50"
+        >
+          Siguiente
+        </button>
+      </div>
+      {toast && <Toast message={toast} type="error" />}
+    </div>
+  );
+};
+
+export default PointsStep1;

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import Toast from '../components/Toast';
+import { UserProfile, mockAddPoints } from '../api/mock';
+
+interface Props {
+  profile: UserProfile;
+  onBack: () => void;
+  onNext: (updated: UserProfile, added: number, expires: string) => void;
+}
+
+const RATE = 10; // 1 punto cada 10$
+
+const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
+  const [amount, setAmount] = React.useState('');
+  const [toast, setToast] = React.useState<string | null>(null);
+
+  const points = Math.floor((parseFloat(amount) || 0) / RATE);
+
+  const handleNext = () => {
+    const value = parseFloat(amount);
+    if (isNaN(value) || value < RATE) {
+      setToast(`El monto es muy pequeño`);
+      setTimeout(() => setToast(null), 3000);
+      return;
+    }
+    mockAddPoints(value).then(({ profile: p, added, expires }) => {
+      onNext(p, added, expires);
+    });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center relative">
+      <button onClick={onBack} className="absolute top-4 left-4 text-2xl">←</button>
+      <div className="bg-white p-8 rounded-xl shadow-md w-full max-w-lg flex flex-col gap-6">
+        <div className="flex items-center gap-4">
+          <img
+            src={profile.avatar || 'https://via.placeholder.com/80'}
+            alt={profile.name}
+            className="w-16 h-16 rounded-full"
+          />
+          <div>
+            <h3 className="text-xl font-semibold">{profile.name}</h3>
+            <p className="text-sm text-gray-600">{profile.email}</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <p className="font-semibold">Puntos actuales</p>
+            <p>{profile.points}</p>
+          </div>
+          <div>
+            <p className="font-semibold">Próximo nivel</p>
+            <p>
+              {profile.nextLevel} ({profile.pointsToNext} pts)
+            </p>
+          </div>
+          <div>
+            <p className="font-semibold">Total canjeado</p>
+            <p>{profile.totalRedeemed}</p>
+          </div>
+        </div>
+        {profile.expiring && (
+          <div className="text-center text-sm text-red-500">
+            Próximos a vencer: {profile.expiring.points} pts el {profile.expiring.date}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <span>Ganas 1 punto por cada ${RATE}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span>$</span>
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="flex-1 px-3 py-2 border rounded"
+          />
+          <span className="whitespace-nowrap">{points} pts</span>
+        </div>
+        <button
+          onClick={handleNext}
+          className="w-full py-2 border border-green-500 rounded-full text-green-600 hover:bg-green-50"
+        >
+          Acreditar puntos
+        </button>
+      </div>
+      {toast && <Toast message={toast} type="error" />}
+    </div>
+  );
+};
+
+export default PointsStep2;

--- a/src/renderer/pages/PointsStepFinal.tsx
+++ b/src/renderer/pages/PointsStepFinal.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from 'react';
+import Toast from '../components/Toast';
+import { UserProfile } from '../api/mock';
+
+interface Props {
+  profile: UserProfile;
+  added: number;
+  expires: string;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+const PointsStepFinal: React.FC<Props> = ({ profile, added, expires, onBack, onClose }) => {
+  const [toast, setToast] = React.useState<string | null>(null);
+
+  useEffect(() => {
+    setToast('Los puntos fueron acreditados correctamente');
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center relative">
+      <button onClick={onBack} className="absolute top-4 left-4 text-2xl">←</button>
+      <div className="bg-white p-8 rounded-xl shadow-md w-full max-w-lg flex flex-col gap-6">
+        <div className="flex items-center gap-4">
+          <img
+            src={profile.avatar || 'https://via.placeholder.com/80'}
+            alt={profile.name}
+            className="w-16 h-16 rounded-full"
+          />
+          <div>
+            <h3 className="text-xl font-semibold">{profile.name}</h3>
+            <p className="text-sm text-gray-600">{profile.email}</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <p className="font-semibold">Puntos actuales</p>
+            <p>{profile.points}</p>
+          </div>
+          <div>
+            <p className="font-semibold">Próximo nivel</p>
+            <p>
+              {profile.nextLevel} ({profile.pointsToNext} pts)
+            </p>
+          </div>
+          <div>
+            <p className="font-semibold">Total canjeado</p>
+            <p>{profile.totalRedeemed}</p>
+          </div>
+        </div>
+        {profile.expiring && (
+          <div className="text-center text-sm text-red-500">
+            Próximos a vencer: {profile.expiring.points} pts el {profile.expiring.date}
+          </div>
+        )}
+        <div className="text-center">
+          Sumaste <strong>{added} puntos</strong> y tenés hasta {expires} para gastarlos.
+        </div>
+        <button
+          onClick={onClose}
+          className="w-full py-2 border border-green-500 rounded-full text-green-600 hover:bg-green-50"
+        >
+          Cerrar
+        </button>
+      </div>
+      {toast && <Toast message={toast} />}
+    </div>
+  );
+};
+
+export default PointsStepFinal;

--- a/src/renderer/pages/PosSelect.tsx
+++ b/src/renderer/pages/PosSelect.tsx
@@ -18,7 +18,8 @@ const PosSelect: React.FC<Props> = ({ onSelect, onCancel }) => {
   const filtered = poses.filter(p => p.name.toLowerCase().includes(search.toLowerCase()));
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center relative">
+      <button onClick={onCancel} className="absolute top-4 left-4 text-2xl">←</button>
       <div className="bg-white p-8 rounded-xl shadow-md w-full max-w-lg flex flex-col gap-4">
         <h1 className="text-xl font-semibold text-center">Seleccione el punto de venta</h1>
         <input
@@ -39,12 +40,6 @@ const PosSelect: React.FC<Props> = ({ onSelect, onCancel }) => {
             </button>
           ))}
         </div>
-        <button
-          onClick={onCancel}
-          className="mt-2 px-4 py-1 border border-red-500 rounded-full text-red-600 hover:bg-red-50"
-        >
-          Cancelar
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- style header with background and shadow
- add multi-step UI to load points with user lookup, amount entry, and confirmation
- show toast notifications and back arrow navigation across screens

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Cannot find module 'tailwindcss')

------
https://chatgpt.com/codex/tasks/task_e_68a8724fc4cc83288200edaaca7b1178