### PR TITLE
Ajustar layout entre header, main y footer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import React from 'react';
 import LoginUser from './pages/LoginUser';
 import BrandSelect from './pages/BrandSelect';
 import Home from './pages/Home';
@@ -29,22 +29,7 @@ const App: React.FC = () => {
   const [expires, setExpires] = React.useState('');
   const [theme, setTheme] = React.useState<'light' | 'dark'>('light');
 
-  // Refs y estado para el padding dinámico
-  const headerRef = useRef<HTMLDivElement>(null);
-  const footerRef = useRef<HTMLDivElement>(null);
-  const [mainPadding, setMainPadding] = useState({ top: 0, bottom: 0 });
-
-
-  useLayoutEffect(() => {
-    const updatePadding = () => {
-      const headerHeight = headerRef.current?.offsetHeight || 0;
-      const footerHeight = footerRef.current?.offsetHeight || 0;
-      setMainPadding({ top: headerHeight, bottom: footerHeight });
-    };
-    updatePadding();
-    window.addEventListener('resize', updatePadding);
-    return () => window.removeEventListener('resize', updatePadding);
-  }, []);
+  // El layout se maneja con flexbox, por lo que no es necesario calcular paddings dinámicos
 
   React.useEffect(() => {
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
@@ -164,19 +149,10 @@ const App: React.FC = () => {
     );
 
   return (
-    <div className="h-screen flex flex-col bg-gray-900">
-      <Header ref={headerRef} onChangeBrand={handleChangeBrand} onLogout={handleLogout} />
-      <main
-        className="flex-1 overflow-y-auto brand-scroll"
-        style={{
-          paddingTop: mainPadding.top,
-          paddingBottom: mainPadding.bottom,
-          maxHeight: `calc(100vh - ${mainPadding.top + mainPadding.bottom}px)`,
-        }}
-      >
-        {content}
-      </main>
-      <Footer ref={footerRef} theme={theme} onToggle={toggleTheme} />
+    <div className="h-screen flex flex-col bg-gray-900 overflow-hidden">
+      <Header onChangeBrand={handleChangeBrand} onLogout={handleLogout} />
+      <main className="flex-1 overflow-y-auto brand-scroll">{content}</main>
+      <Footer theme={theme} onToggle={toggleTheme} />
     </div>
   );
 };

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -33,7 +33,10 @@ const Footer = forwardRef<HTMLDivElement, Props>(({ theme, onToggle }, ref) => {
   };
 
   return (
-    <footer ref={ref} className="fixed bottom-0 left-0 right-0 z-50 w-full px-4 sm:px-8 py-2 sm:py-3 bg-white dark:bg-gray-900 shadow-md border-t border-green-200 dark:border-gray-700 flex justify-center items-center">
+    <footer
+      ref={ref}
+      className="w-full px-4 sm:px-8 py-2 sm:py-3 bg-white dark:bg-gray-900 shadow-md border-t border-green-200 dark:border-gray-700 flex justify-center items-center flex-shrink-0"
+    >
       <div className="flex items-center gap-3">
         <button
           ref={buttonRef}

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -25,7 +25,10 @@ const Header = forwardRef<HTMLDivElement, Props>(({ onChangeBrand, onLogout }, r
     : "h-8 sm:h-10 md:h-12 w-auto";
 
   return (
-    <header ref={ref} className="fixed top-0 left-0 right-0 z-50 w-full px-4 sm:px-8 py-2 sm:py-3 bg-white dark:bg-gray-900 shadow-md border-b border-green-200 dark:border-gray-700">
+    <header
+      ref={ref}
+      className="w-full px-4 sm:px-8 py-2 sm:py-3 bg-white dark:bg-gray-900 shadow-md border-b border-green-200 dark:border-gray-700 flex-shrink-0"
+    >
       <div className="flex flex-col sm:flex-row justify-between items-center gap-2 sm:gap-0">
         <div className="flex items-center gap-3 max-h-10">
           <img


### PR DESCRIPTION
## Summary
- Simplify layout using flexbox to keep header and footer fixed outside scroll
- Remove dynamic padding logic in main and ref-based measurements
- Ensure main occupies full space between header and footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b76a8ddc83289cbedc315f8b2d33