### PR TITLE
chore: remove default menu bar

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,22 +1,28 @@
-import { app, BrowserWindow } from "electron"
+import { app, BrowserWindow, Menu } from "electron"
 import { join } from "node:path"
 
 const isDev = process.env.NODE_ENV === "development"
 
 function createWindow() {
   const win = new BrowserWindow({
-    width: 1024, height: 768, show: false,
+    width: 1024,
+    height: 768,
+    show: false,
     webPreferences: {
       preload: join(__dirname, "preload.js"),
-      contextIsolation: true, nodeIntegration: false, sandbox: true
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true
     }
   })
+  Menu.setApplicationMenu(null)
   win.once("ready-to-show", () => win.show())
 
   if (isDev) {
-    win.loadURL("http://localhost:5173")          // 👈 dev con Vite
+    win.loadURL("http://localhost:5173") // 👈 dev con Vite
   } else {
     win.loadFile(join(__dirname, "../renderer/index.html")) // 👈 prod
   }
 }
+
 app.whenReady().then(createWindow)


### PR DESCRIPTION
## Summary
- remove Electron default menu bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68acb3a8a3908328b80719dc13221670