### PR TITLE
Handle login errors and basic authorization

### DIFF
--- a/src/renderer/api/auth.ts
+++ b/src/renderer/api/auth.ts
@@ -28,12 +28,17 @@ export interface AuthResponse {
 }
 
 export async function login(username: string, password: string): Promise<AuthResponse> {
-  const params = new URLSearchParams({ username, password, grant_type:"password" });
+  const params = new URLSearchParams({ username, password, grant_type: 'password' });
   const { data } = await axiosClient.post<AuthResponse>(
-    `/awer-auth/oauth/token?grant_type=password&username=${username}&password=${password}`,
-    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+    '/awer-auth/oauth/token',
+    params,
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic V0...'
+      }
+    }
   );
-  console.log("DATA: ", data)
   return data;
 }
 

--- a/src/renderer/api/axiosClient.ts
+++ b/src/renderer/api/axiosClient.ts
@@ -9,10 +9,9 @@ console.log("BaseURL: ", import.meta.env.VITE_API_BASE_URL)
 
 axiosClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
-  if (token) {
-    if (config.headers) {
-      config.headers['Authorization'] = `Bearer ${token}`;
-    }
+  // Only attach bearer token if no Authorization header is already provided
+  if (token && config.headers && !config.headers['Authorization']) {
+    config.headers['Authorization'] = `Bearer ${token}`;
   }
   return config;
 });

--- a/src/renderer/pages/LoginUser.tsx
+++ b/src/renderer/pages/LoginUser.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { login } from '../api/auth';
 import Spinner from '../components/Spinner';
+import Toast from '../components/Toast';
 
 interface Props {
   onLogin: () => void;
@@ -11,6 +12,7 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
   const [password, setPassword] = React.useState('');
   const [loading, setLoading] = React.useState(false);
   const [isDark, setIsDark] = React.useState(false);
+  const [toast, setToast] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     const html = document.documentElement;
@@ -25,11 +27,17 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    const { access_token, refresh_token } = await login(user, password);
-    localStorage.setItem('token', access_token);
-    localStorage.setItem('refresh_token', refresh_token);
-    setLoading(false);
-    onLogin();
+    try {
+      const { access_token, refresh_token } = await login(user, password);
+      localStorage.setItem('token', access_token);
+      localStorage.setItem('refresh_token', refresh_token);
+      onLogin();
+    } catch {
+      setToast('Ocurrió un error, prueba de nuevo');
+      setTimeout(() => setToast(null), 3000);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const logoSrc = isDark ? "/logo-white.png" : "/logo-principal.png";
@@ -86,6 +94,7 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
           {loading ? 'Ingresando...' : 'Iniciar sesión'}
         </button>
       </form>
+      {toast && <Toast message={toast} type="error" />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Avoid overriding custom Authorization headers in axios client
- Use Basic token for login requests
- Display toast on login failures instead of spinning indefinitely

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acc3e9f98c832887317b6c484b95d8