### PR TITLE
Fetch company info and handle unauthorized responses

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -83,13 +83,12 @@ const App: React.FC = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('refresh_token');
     localStorage.removeItem('brand');
-    localStorage.removeItem('pos');
+    localStorage.removeItem('companyId');
     setScreen('login1');
   };
 
   const handleChangeBrand = () => {
     localStorage.removeItem('brand');
-    localStorage.removeItem('pos');
     setScreen('login2');
   };
 

--- a/src/renderer/api/auth.ts
+++ b/src/renderer/api/auth.ts
@@ -35,11 +35,23 @@ export async function login(username: string, password: string): Promise<AuthRes
     {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        Authorization: 'Basic V0...'
+        Authorization: `Basic ${import.meta.env.VITE_BASIC_AUTH}`
       }
     }
   );
   return data;
+}
+
+export interface UserInfo {
+  companyId: string;
+}
+
+export async function fetchCurrentUser(): Promise<UserInfo> {
+  const { data } = await axiosClient.get<string>('/awer-core/users/me', { responseType: 'text' });
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(data, 'application/xml');
+  const companyId = xmlDoc.querySelector('companyId')?.textContent ?? '';
+  return { companyId };
 }
 
 export async function authenticate(): Promise<boolean> {

--- a/src/renderer/api/axiosClient.ts
+++ b/src/renderer/api/axiosClient.ts
@@ -5,8 +5,6 @@ const axiosClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
-console.log("BaseURL: ", import.meta.env.VITE_API_BASE_URL)
-
 axiosClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
   // Only attach bearer token if no Authorization header is already provided
@@ -18,30 +16,14 @@ axiosClient.interceptors.request.use((config) => {
 
 axiosClient.interceptors.response.use(
   (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-      const refreshToken = localStorage.getItem('refresh_token');
-      if (refreshToken) {
-        try {
-          const params = new URLSearchParams({ refresh_token: refreshToken });
-          const { data } = await axios.post(
-            `${axiosClient.defaults.baseURL}/awer-auth/oauth/token?grant_type=refresh_token`,
-            params,
-            { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
-          );
-          localStorage.setItem('token', data.access_token);
-          localStorage.setItem('refresh_token', data.refresh_token);
-          if (originalRequest.headers) {
-            originalRequest.headers['Authorization'] = `Bearer ${data.access_token}`;
-          }
-          return axiosClient(originalRequest);
-        } catch (refreshError) {
-          localStorage.removeItem('token');
-          localStorage.removeItem('refresh_token');
-        }
-      }
+  (error) => {
+    const requestUrl: string = error.config?.url ?? '';
+    if (error.response?.status === 401 && !requestUrl.includes('/awer-auth/oauth/token')) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('refresh_token');
+      localStorage.removeItem('brand');
+      localStorage.removeItem('companyId');
+      window.location.reload();
     }
     return Promise.reject(error);
   },

--- a/src/renderer/pages/LoginUser.tsx
+++ b/src/renderer/pages/LoginUser.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { login } from '../api/auth';
+import { login, fetchCurrentUser } from '../api/auth';
 import Spinner from '../components/Spinner';
 import Toast from '../components/Toast';
 
@@ -31,8 +31,12 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
       const { access_token, refresh_token } = await login(user, password);
       localStorage.setItem('token', access_token);
       localStorage.setItem('refresh_token', refresh_token);
+      const { companyId } = await fetchCurrentUser();
+      if (companyId) localStorage.setItem('companyId', companyId);
       onLogin();
     } catch {
+      localStorage.removeItem('token');
+      localStorage.removeItem('refresh_token');
       setToast('Ocurrió un error, prueba de nuevo');
       setTimeout(() => setToast(null), 3000);
     } finally {


### PR DESCRIPTION
## Summary
- Read Basic auth for login from env variable
- Log out when API responses return 401
- Keep POS selection in localStorage on logout or brand change
- After login, fetch `/awer-core/users/me` and store `companyId`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68accc0f557c83288f796ba6601c40cb