### PR TITLE
fix: redirect to POS selection when no POS stored

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -80,8 +80,13 @@ const App: React.FC = () => {
 
   const handleLogged = () => {
     const brand = localStorage.getItem('brand');
-    if (brand) setScreen('home');
-    else setScreen('login2');
+    if (!brand) {
+      setScreen('login2');
+      return;
+    }
+    const stored = localStorage.getItem('pos');
+    if (!stored) setScreen('pos');
+    else setScreen('home');
   };
 
   const handleBrand = (brand: Brand) => {


### PR DESCRIPTION
## Summary
- check for a stored point of sale after login to ensure proper routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add3b2a7fc83288bbff5cdb870d81c