### PR TITLE
Load points config before showing PointsStep2

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -63,11 +63,6 @@ const App: React.FC = () => {
         handleLogout();
         return;
       }
-      const brand = localStorage.getItem('brand');
-      if (!brand) {
-        setScreen('login2');
-        return;
-      }
       const stored = localStorage.getItem('pos');
       if (!stored) {
         setScreen('pos');
@@ -79,11 +74,6 @@ const App: React.FC = () => {
   }, []);
 
   const handleLogged = () => {
-    const brand = localStorage.getItem('brand');
-    if (!brand) {
-      setScreen('login2');
-      return;
-    }
     const stored = localStorage.getItem('pos');
     if (!stored) setScreen('pos');
     else setScreen('home');

--- a/src/renderer/api/auth.ts
+++ b/src/renderer/api/auth.ts
@@ -96,11 +96,3 @@ export async function fetchBrands(): Promise<Brand[]> {
   ];
 }
 
-export async function fetchPos(brandId: string): Promise<Pos[]> {
-  // TODO: return (await axiosClient.get<Pos[]>(`/brands/${brandId}/pos`)).data;
-  await delay(500);
-  return Array.from({ length: 20 }).map((_, i) => ({
-    id: `${brandId}-pos-${i + 1}`,
-    name: `Sucursal ${i + 1}`,
-  }));
-}

--- a/src/renderer/api/points.ts
+++ b/src/renderer/api/points.ts
@@ -113,6 +113,7 @@ export async function addPoints(amount: number): Promise<{ profile: UserProfile;
   await delay(500);
   const rate = 10;
   const added = Math.floor(amount / rate);
+  if(!currentUser) return {profile: {id:"1",name:"",level:"",nextLevel:"",pointsToNext:2424, email: "", dni: "", points:12, totalRedeemed:12}, added, expires: '2025-12-31'}
   currentUser.points += added;
   currentUser.pointsToNext -= added;
   if (currentUser.pointsToNext <= 0) {

--- a/src/renderer/api/points.ts
+++ b/src/renderer/api/points.ts
@@ -12,6 +12,7 @@ export interface UserProfile {
   pointsToNext: number;
   totalRedeemed: number;
   expiringPoints?: number;
+  expiringDate?: string;
 }
 
 export interface PointsConfig {
@@ -52,13 +53,17 @@ interface ApiUser {
 
 function mapUser(u: ApiUser): UserProfile {
   let expiringPoints: number | undefined;
+  let expiringDate: string | undefined;
   if (u.pointsToExpire && u.expireDate) {
     const [y, m, d] = u.expireDate;
     const expiration = new Date(y, m - 1, d);
     const diffDays = Math.ceil(
       (expiration.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
     );
-    if (diffDays < 4) expiringPoints = u.pointsToExpire;
+    if (diffDays < 4) {
+      expiringPoints = u.pointsToExpire;
+      expiringDate = `${String(d).padStart(2, '0')}/${String(m).padStart(2, '0')}/${y}`;
+    }
   }
   return {
     id: `${u.dni ?? ''}-${u.email}`,
@@ -72,6 +77,7 @@ function mapUser(u: ApiUser): UserProfile {
     pointsToNext: u.pointsToNextLevel,
     totalRedeemed: u.totalRedeemedPoints,
     expiringPoints,
+    expiringDate,
   };
 }
 

--- a/src/renderer/api/points.ts
+++ b/src/renderer/api/points.ts
@@ -14,6 +14,11 @@ export interface UserProfile {
   expiring?: { points: number; date: string };
 }
 
+export interface PointsConfig {
+  unitAmount: number | null;
+  pointsPerUnit: number | null;
+}
+
 const mockUsers: UserProfile[] = [
   {
     id: '1',
@@ -70,6 +75,17 @@ const mockUsers: UserProfile[] = [
 let currentUser: UserProfile = mockUsers[0];
 
 const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+export async function fetchPointsConfig(): Promise<PointsConfig> {
+  const { data } = await axiosClient.get<{
+    unitAmount?: number | null;
+    pointsPerUnit?: number | null;
+  }>("/awer-core/reward/config");
+  return {
+    unitAmount: data.unitAmount ?? null,
+    pointsPerUnit: data.pointsPerUnit ?? null,
+  };
+}
 
 export async function searchUsers(query: string): Promise<string[]> {
   // TODO: return (await axiosClient.get<string[]>('/users/search', { params: { q: query } })).data;

--- a/src/renderer/api/points.ts
+++ b/src/renderer/api/points.ts
@@ -11,7 +11,7 @@ export interface UserProfile {
   nextLevel: string;
   pointsToNext: number;
   totalRedeemed: number;
-  expiring?: { points: number; date: string };
+  expiringPoints?: number;
 }
 
 export interface PointsConfig {
@@ -41,21 +41,37 @@ interface ApiUser {
   pointsToNextLevel: number;
   nextLevel: string;
   userPoints: number;
+  availablePoints?: number;
   userLevel: string;
   email: string;
+  avatar?: string | null;
+  pointsToExpire?: number | null;
+  expireDate?: [number, number, number] | null;
+  totalRedeemedPoints: number;
 }
 
 function mapUser(u: ApiUser): UserProfile {
+  let expiringPoints: number | undefined;
+  if (u.pointsToExpire && u.expireDate) {
+    const [y, m, d] = u.expireDate;
+    const expiration = new Date(y, m - 1, d);
+    const diffDays = Math.ceil(
+      (expiration.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+    );
+    if (diffDays < 4) expiringPoints = u.pointsToExpire;
+  }
   return {
     id: `${u.dni ?? ''}-${u.email}`,
     name: `${u.name} ${u.surname}`.trim(),
     email: u.email,
     dni: u.dni ?? '',
-    points: u.userPoints,
+    avatar: u.avatar ?? undefined,
+    points: u.availablePoints ?? u.userPoints,
     level: u.userLevel,
     nextLevel: u.nextLevel,
     pointsToNext: u.pointsToNextLevel,
-    totalRedeemed: 0,
+    totalRedeemed: u.totalRedeemedPoints,
+    expiringPoints,
   };
 }
 

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface Props {
+  message: string;
+  children: React.ReactNode;
+}
+
+const Tooltip: React.FC<Props> = ({ message, children }) => (
+  <div className="relative inline-block group">
+    {children}
+    <div className="pointer-events-none absolute left-1/2 z-50 hidden -translate-x-1/2 -translate-y-full group-hover:flex flex-col items-center">
+      <div className="mb-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 shadow-md dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
+        {message}
+      </div>
+      <div className="h-2 w-2 -mt-1 rotate-45 border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" />
+    </div>
+  </div>
+);
+
+export default Tooltip;

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -8,8 +8,8 @@ interface Props {
 const Tooltip: React.FC<Props> = ({ message, children }) => (
   <div className="relative inline-block group">
     {children}
-    <div className="pointer-events-none absolute left-1/2 z-50 hidden -translate-x-1/2 -translate-y-full group-hover:flex flex-col items-center">
-      <div className="mb-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 shadow-md dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
+    <div className="pointer-events-none absolute left-1/2 top-0 z-50 hidden -translate-x-1/2 -translate-y-full group-hover:flex flex-col items-center">
+      <div className="mb-2 max-w-[90vw] sm:max-w-xs md:max-w-sm rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 shadow-md break-words whitespace-pre-line dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
         {message}
       </div>
       <div className="h-2 w-2 -mt-1 rotate-45 border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" />

--- a/src/renderer/context/CompanyContext.tsx
+++ b/src/renderer/context/CompanyContext.tsx
@@ -20,11 +20,6 @@ export const CompanyProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const [companyLogo, setCompanyLogo] = React.useState('');
   const [branches, setBranches] = React.useState<Branch[]>([]);
 
-  console.log(companyId)
-  console.log(companyName)
-  console.log(companyLogo)
-  console.log(branches)
-
   return (
     <CompanyContext.Provider value={{ companyId, companyName, companyLogo, branches, setCompanyId, setCompanyName, setCompanyLogo, setBranches }}>
       {children}

--- a/src/renderer/context/PointsConfigContext.tsx
+++ b/src/renderer/context/PointsConfigContext.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface PointsConfigContextValue {
+  unitAmount: number | null;
+  pointsPerUnit: number | null;
+  setUnitAmount: React.Dispatch<React.SetStateAction<number | null>>;
+  setPointsPerUnit: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+const PointsConfigContext = React.createContext<PointsConfigContextValue | undefined>(undefined);
+
+export const PointsConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [unitAmount, setUnitAmount] = React.useState<number | null>(null);
+  const [pointsPerUnit, setPointsPerUnit] = React.useState<number | null>(null);
+
+  return (
+    <PointsConfigContext.Provider value={{ unitAmount, pointsPerUnit, setUnitAmount, setPointsPerUnit }}>
+      {children}
+    </PointsConfigContext.Provider>
+  );
+};
+
+export const usePointsConfig = (): PointsConfigContextValue => {
+  const context = React.useContext(PointsConfigContext);
+  if (!context) {
+    throw new Error('usePointsConfig must be used within a PointsConfigProvider');
+  }
+  return context;
+};
+

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import './index.css';
 import { CompanyProvider } from './context/CompanyContext';
+import { PointsConfigProvider } from './context/PointsConfigContext';
 
 createRoot(document.getElementById("root")!).render(
   <CompanyProvider>
-    <App />
+    <PointsConfigProvider>
+      <App />
+    </PointsConfigProvider>
   </CompanyProvider>
 );

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const Home: React.FC<Props> = ({ onChangePos, onLoadPoints }) => {
-  const { branches } = useCompany();
+  const { branches, companyLogo, companyName } = useCompany();
   const posId = localStorage.getItem("pos");
   let posName = "Punto de Venta";
   if (posId) {
@@ -23,12 +23,24 @@ const Home: React.FC<Props> = ({ onChangePos, onLoadPoints }) => {
         <div className="relative">
           <div className="h-24 sm:h-28 bg-gradient-to-r from-green-400 via-emerald-500 to-green-600 dark:from-green-700 dark:via-emerald-700 dark:to-green-800" />
           <div className="absolute -bottom-10 left-1/2 -translate-x-1/2">
-            <div className="h-20 w-20 sm:h-24 sm:w-24 rounded-2xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 shadow-xl flex items-center justify-center">
-              {/* Ícono POS */}
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-10 w-10 text-green-600 dark:text-green-400">
-                <path d="M3 6.75A2.25 2.25 0 0 1 5.25 4.5h13.5A2.25 2.25 0 0 1 21 6.75v7.5A2.25 2.25 0 0 1 18.75 16.5H5.25A2.25 2.25 0 0 1 3 14.25v-7.5Z" />
-                <path d="M3.75 18.375A1.875 1.875 0 0 1 5.625 16.5h12.75a1.875 1.875 0 0 1 1.875 1.875c0 .414-.336.75-.75.75H4.5a.75.75 0 0 1-.75-.75Z" />
-              </svg>
+            <div className="h-20 w-20 sm:h-24 sm:w-24 rounded-2xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 shadow-xl flex items-center justify-center p-1">
+              {companyLogo ? (
+                <img
+                  src={companyLogo.startsWith('http') ? companyLogo : `https:${companyLogo}`}
+                  alt={companyName || 'Logo'}
+                  className="h-full w-full object-contain rounded-xl border border-gray-300 dark:border-gray-600"
+                />
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="h-10 w-10 text-green-600 dark:text-green-400"
+                >
+                  <path d="M3 6.75A2.25 2.25 0 0 1 5.25 4.5h13.5A2.25 2.25 0 0 1 21 6.75v7.5A2.25 2.25 0 0 1 18.75 16.5H5.25A2.25 2.25 0 0 1 3 14.25v-7.5Z" />
+                  <path d="M3.75 18.375A1.875 1.875 0 0 1 5.625 16.5h12.75a1.875 1.875 0 0 1 1.875 1.875c0 .414-.336.75-.75.75H4.5a.75.75 0 0 1-.75-.75Z" />
+                </svg>
+              )}
             </div>
           </div>
         </div>

--- a/src/renderer/pages/PointsStep1.tsx
+++ b/src/renderer/pages/PointsStep1.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import Toast from "../components/Toast";
 import Spinner from "../components/Spinner";
-import { fetchUser, fetchEmailsByDni, UserProfile } from "../api/points";
+import {
+  fetchUsersByDni,
+  fetchUserByDniEmail,
+  UserProfile,
+} from "../api/points";
 
 interface Props {
   onBack: () => void;
@@ -22,14 +26,14 @@ const PointsStep1: React.FC<Props> = ({ onBack, onNext }) => {
   const handleSearch = () => {
     if (!dni) return;
     setLoading(true);
-    fetchEmailsByDni(dni)
+    fetchUsersByDni(dni)
       .then((res) => {
         if (res.length === 0) {
           showError("DNI no encontrado");
         } else if (res.length === 1) {
-          return fetchUser(res[0]).then(onNext);
+          onNext(res[0]);
         } else {
-          setEmails(res);
+          setEmails(res.map((u) => u.email));
         }
       })
       .catch((e) => showError(e.message))
@@ -38,7 +42,7 @@ const PointsStep1: React.FC<Props> = ({ onBack, onNext }) => {
 
   const handleSelectEmail = (email: string) => {
     setLoading(true);
-    fetchUser(email)
+    fetchUserByDniEmail(dni, email)
       .then(onNext)
       .catch((e) => showError(e.message))
       .finally(() => setLoading(false));

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Toast from "../components/Toast";
 import Spinner from "../components/Spinner";
+import Tooltip from "../components/Tooltip";
 import { UserProfile, addPoints, fetchPointsConfig } from "../api/points";
 import { usePointsConfig } from "../context/PointsConfigContext";
 import userIcon from "../assets/user-default.svg";
@@ -187,15 +188,16 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
           {/* Tasa y formulario */}
           <div>
             {configInvalid && (
-              <div className="mb-4 flex items-start justify-between rounded-xl border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
+              <div className="mb-4 flex items-start justify-between rounded-xl border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-600 dark:bg-yellow-900/40 dark:text-yellow-200">
                 <p className="text-sm">Su empresa no configuró la cantidad de puntos a otorgar por cada monto.</p>
-                <button
-                  type="button"
-                  className="ml-4 flex h-6 w-6 items-center justify-center rounded-full border border-yellow-400 text-xs font-bold"
-                  title="Para eso la empresa debe ingresar a https://gestion.awerreviews.com. Dirigirse a Fidelización en el slide de la izquierda y seleccionar Awer Loyalty. Allí al apartado Niveles y acciones y configurar allí"
-                >
-                  ?
-                </button>
+                <Tooltip message="Para eso la empresa debe ingresar a https://gestion.awerreviews.com. Dirigirse a Fidelización en el slide de la izquierda y seleccionar Awer Loyalty. Allí al apartado Niveles y acciones y configurar allí">
+                  <button
+                    type="button"
+                    className="ml-4 flex h-6 w-6 items-center justify-center rounded-full border border-yellow-400 text-xs font-bold text-yellow-700 dark:border-yellow-600 dark:text-yellow-200"
+                  >
+                    ?
+                  </button>
+                </Tooltip>
               </div>
             )}
             <p className="text-sm sm:text-base text-gray-700 dark:text-gray-300 mb-2">

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -48,6 +48,7 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
     unitAmount && pointsPerUnit
       ? Math.floor((valueNum * pointsPerUnit) / unitAmount)
       : 0;
+  const configInvalid = !unitAmount || !pointsPerUnit;
 
   const handleNext = () => {
     const value = parseFloat(amount);
@@ -185,6 +186,18 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
 
           {/* Tasa y formulario */}
           <div>
+            {configInvalid && (
+              <div className="mb-4 flex items-start justify-between rounded-xl border border-yellow-300 bg-yellow-50 p-4 text-yellow-800">
+                <p className="text-sm">Su empresa no configuró la cantidad de puntos a otorgar por cada monto.</p>
+                <button
+                  type="button"
+                  className="ml-4 flex h-6 w-6 items-center justify-center rounded-full border border-yellow-400 text-xs font-bold"
+                  title="Para eso la empresa debe ingresar a https://gestion.awerreviews.com. Dirigirse a Fidelización en el slide de la izquierda y seleccionar Awer Loyalty. Allí al apartado Niveles y acciones y configurar allí"
+                >
+                  ?
+                </button>
+              </div>
+            )}
             <p className="text-sm sm:text-base text-gray-700 dark:text-gray-300 mb-2">
               Ganás <b>{pointsPerUnit ?? 0} punto{pointsPerUnit === 1 ? '' : 's'}</b> por cada <b>${unitAmount ?? 0}</b>
             </p>

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -88,7 +88,7 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
   return (
     <div className="min-h-full w-full flex items-center justify-center px-3 sm:px-6 py-6">
       {/* Card principal */}
-      <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 rounded-3xl shadow-2xl overflow-hidden animate-fade-in relative">
+      <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 rounded-3xl shadow-2xl animate-fade-in relative overflow-visible">
         {/* Encabezado visual + Botón volver */}
         <div className="relative">
           <button

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -179,9 +179,9 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
               </div>
             </div>
 
-            {profile.expiringPoints !== undefined && (
+            {profile.expiringPoints !== undefined && profile.expiringDate && (
               <div className="mt-3 text-center text-xs sm:text-sm text-red-600 dark:text-red-400">
-                Próximos a vencer: <b>{profile.expiringPoints}</b> pts
+                Próximos a vencer: <b>{profile.expiringPoints}</b> pts - {profile.expiringDate}
               </div>
             )}
           </div>

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -124,6 +124,7 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
             <div className="flex items-start gap-4">
               <img
                 src={profile.avatar || userIcon}
+                onError={(e) => (e.currentTarget.src = userIcon)}
                 alt={profile.name}
                 className="w-16 h-16 sm:w-20 sm:h-20 rounded-full border-2 border-green-400 dark:border-green-600 object-cover bg-white dark:bg-gray-800 flex-shrink-0"
               />
@@ -178,9 +179,9 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
               </div>
             </div>
 
-            {profile.expiring && (
+            {profile.expiringPoints !== undefined && (
               <div className="mt-3 text-center text-xs sm:text-sm text-red-600 dark:text-red-400">
-                Próximos a vencer: <b>{profile.expiring.points}</b> pts el <b>{profile.expiring.date}</b>
+                Próximos a vencer: <b>{profile.expiringPoints}</b> pts
               </div>
             )}
           </div>

--- a/src/renderer/pages/PointsStepFinal.tsx
+++ b/src/renderer/pages/PointsStepFinal.tsx
@@ -79,6 +79,7 @@ const PointsStepFinal: React.FC<Props> = ({ profile, added, expires, onBack, onC
             <div className="flex items-start gap-4">
               <img
                 src={profile.avatar || userIcon}
+                onError={(e) => (e.currentTarget.src = userIcon)}
                 alt={profile.name}
                 className="w-16 h-16 sm:w-20 sm:h-20 rounded-full border-2 border-green-400 dark:border-green-600 object-cover bg-white dark:bg-gray-800 flex-shrink-0"
               />
@@ -134,9 +135,9 @@ const PointsStepFinal: React.FC<Props> = ({ profile, added, expires, onBack, onC
             </div>
 
             {/* Vencimientos (si existen) */}
-            {profile.expiring && (
+            {profile.expiringPoints !== undefined && (
               <div className="mt-3 text-center text-xs sm:text-sm text-red-600 dark:text-red-400">
-                Próximos a vencer: <b>{profile.expiring.points}</b> pts el <b>{profile.expiring.date}</b>
+                Próximos a vencer: <b>{profile.expiringPoints}</b> pts
               </div>
             )}
           </div>

--- a/src/renderer/pages/PointsStepFinal.tsx
+++ b/src/renderer/pages/PointsStepFinal.tsx
@@ -135,9 +135,9 @@ const PointsStepFinal: React.FC<Props> = ({ profile, added, expires, onBack, onC
             </div>
 
             {/* Vencimientos (si existen) */}
-            {profile.expiringPoints !== undefined && (
+            {profile.expiringPoints !== undefined && profile.expiringDate && (
               <div className="mt-3 text-center text-xs sm:text-sm text-red-600 dark:text-red-400">
-                Próximos a vencer: <b>{profile.expiringPoints}</b> pts
+                Próximos a vencer: <b>{profile.expiringPoints}</b> pts - {profile.expiringDate}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add API call to fetch reward configuration and context to store it
- load reward config before rendering PointsStep2 and handle errors
- wrap app with new PointsConfigProvider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_68ae0dabce088328bf41fb1b4ef0d8c4