### PR TITLE
Fetch points config earlier in workflow

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -59,7 +59,10 @@ const App: React.FC = () => {
         setCompanyName(companyName);
         setCompanyLogo(companyLogo);
         setBranches(branches);
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message === 'INVALID_POS') {
+          alert('El punto de venta configurado no corresponde a la empresa o está suspendido');
+        }
         handleLogout();
         return;
       }

--- a/src/renderer/api/auth.ts
+++ b/src/renderer/api/auth.ts
@@ -75,6 +75,12 @@ export async function fetchBranches(companyId: number): Promise<CompanyData> {
   const companyName = data.name;
   const companyLogo = data.companyProfile?.logoFile || '';
 
+  const storedPos = localStorage.getItem('pos');
+  if (storedPos && !branches.some((b) => b.id === Number(storedPos))) {
+    localStorage.removeItem('pos');
+    throw new Error('INVALID_POS');
+  }
+
   return { companyName, companyLogo, branches };
 }
 

--- a/src/renderer/api/auth.ts
+++ b/src/renderer/api/auth.ts
@@ -77,7 +77,6 @@ export async function fetchBranches(companyId: number): Promise<CompanyData> {
 
   const storedPos = localStorage.getItem('pos');
   if (storedPos && !branches.some((b) => b.id === Number(storedPos))) {
-    localStorage.removeItem('pos');
     throw new Error('INVALID_POS');
   }
 

--- a/src/renderer/pages/LoginUser.tsx
+++ b/src/renderer/pages/LoginUser.tsx
@@ -40,10 +40,14 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
       setCompanyLogo(companyLogo);
       setBranches(branches);
       onLogin();
-    } catch {
+    } catch (err) {
       localStorage.removeItem('token');
       localStorage.removeItem('refresh_token');
-      setToast('Ocurrió un error, prueba de nuevo');
+      if (err instanceof Error && err.message === 'INVALID_POS') {
+        setToast('El punto de venta configurado no corresponde a la empresa o está suspendido');
+      } else {
+        setToast('Ocurrió un error, prueba de nuevo');
+      }
       setTimeout(() => setToast(null), 3000);
     } finally {
       setLoading(false);

--- a/src/renderer/pages/PointsStep1.tsx
+++ b/src/renderer/pages/PointsStep1.tsx
@@ -95,7 +95,7 @@ const PointsStep1: React.FC<Props> = ({ onBack, onNext }) => {
 
   return (
     <div className="min-h-full w-full flex items-center justify-center px-3 sm:px-6 py-6">
-      <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 rounded-3xl shadow-2xl overflow-hidden animate-fade-in relative">
+      <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-green-200 dark:border-gray-700 rounded-3xl shadow-2xl animate-fade-in relative overflow-visible">
         <div className="relative">
           <button
             onClick={onBack}

--- a/src/renderer/pages/PointsStep1.tsx
+++ b/src/renderer/pages/PointsStep1.tsx
@@ -126,8 +126,10 @@ const PointsStep1: React.FC<Props> = ({ onBack, onNext }) => {
 
           {configInvalid && (
             <div className="mb-4 flex items-start justify-between rounded-xl border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-600 dark:bg-yellow-900/40 dark:text-yellow-200">
-              <p className="text-sm">Su empresa no configuró la cantidad de puntos a otorgar por cada monto.</p>
-              <Tooltip message="Para eso la empresa debe ingresar a https://gestion.awerreviews.com. Dirigirse a Fidelización en el slide de la izquierda y seleccionar Awer Loyalty. Allí al apartado Niveles y acciones y configurar allí">
+              <p className="text-sm">
+                Su empresa aún no configuró la cantidad de puntos a otorgar por cada monto de compra.
+              </p>
+              <Tooltip message="Para configurarlo, ingrese en https://gestion.awerreviews.com. Luego diríjase al menú 'Fidelización' en el panel lateral, seleccione 'Awer Loyalty' y, dentro de 'Niveles y acciones', establezca la configuración correspondiente.">
                 <button
                   type="button"
                   className="ml-4 flex h-6 w-6 items-center justify-center rounded-full border border-yellow-400 text-xs font-bold text-yellow-700 dark:border-yellow-600 dark:text-yellow-200"

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -172,8 +172,10 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
           <div>
             {configInvalid && (
               <div className="mb-4 flex items-start justify-between rounded-xl border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-600 dark:bg-yellow-900/40 dark:text-yellow-200">
-                <p className="text-sm">Su empresa no configuró la cantidad de puntos a otorgar por cada monto.</p>
-                <Tooltip message="Para eso la empresa debe ingresar a https://gestion.awerreviews.com. Dirigirse a Fidelización en el slide de la izquierda y seleccionar Awer Loyalty. Allí al apartado Niveles y acciones y configurar allí">
+                <p className="text-sm">
+                  Su empresa aún no configuró la cantidad de puntos a otorgar por cada monto de compra.
+                </p>
+                <Tooltip message="Para configurarlo, ingrese en https://gestion.awerreviews.com. Luego diríjase al menú 'Fidelización' en el panel lateral, seleccione 'Awer Loyalty' y, dentro de 'Niveles y acciones', establezca la configuración correspondiente.">
                   <button
                     type="button"
                     className="ml-4 flex h-6 w-6 items-center justify-center rounded-full border border-yellow-400 text-xs font-bold text-yellow-700 dark:border-yellow-600 dark:text-yellow-200"

--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Toast from "../components/Toast";
 import Spinner from "../components/Spinner";
 import Tooltip from "../components/Tooltip";
-import { UserProfile, addPoints, fetchPointsConfig } from "../api/points";
+import { UserProfile, addPoints } from "../api/points";
 import { usePointsConfig } from "../context/PointsConfigContext";
 import userIcon from "../assets/user-default.svg";
 
@@ -20,29 +20,11 @@ const levelColors: Record<string, string> = {
 };
 
 const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext }) => {
-  const { unitAmount, pointsPerUnit, setUnitAmount, setPointsPerUnit } = usePointsConfig();
+  const { unitAmount, pointsPerUnit } = usePointsConfig();
   const [amount, setAmount] = React.useState("");
   const [toast, setToast] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(false);
-  const [configLoading, setConfigLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    fetchPointsConfig()
-      .then(({ unitAmount, pointsPerUnit }) => {
-        setUnitAmount(unitAmount);
-        setPointsPerUnit(pointsPerUnit);
-      })
-      .catch((error: any) => {
-        if (error.response?.status !== 401) {
-          setToast('Ocurrió un error');
-          setTimeout(() => {
-            setToast(null);
-            onBack();
-          }, 3000);
-        }
-      })
-      .finally(() => setConfigLoading(false));
-  }, [onBack, setUnitAmount, setPointsPerUnit]);
+  const configLoading = unitAmount === null || pointsPerUnit === null;
 
   const valueNum = parseFloat(amount) || 0;
   const points =


### PR DESCRIPTION
## Summary
- Fetch points configuration when entering the first step and store it in context
- Show configuration warning in the first step if points settings are missing
- Use existing configuration in the second step instead of fetching again

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68af4980193c832893d840f0b64459b7