### PR TITLE
fix: match points estimation with backend

### DIFF
--- a/src/renderer/pages/PointsStep2.tsx
+++ b/src/renderer/pages/PointsStep2.tsx
@@ -39,7 +39,7 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext, onError }) => {
   const valueNum = parseFloat(amount) || 0;
   const points =
     unitAmount && pointsPerUnit
-      ? Math.floor(valueNum / unitAmount) * pointsPerUnit
+      ? Math.floor(pointsPerUnit * (valueNum / unitAmount))
       : 0;
   const configInvalid = !unitAmount || !pointsPerUnit;
 
@@ -53,7 +53,7 @@ const PointsStep2: React.FC<Props> = ({ profile, onBack, onNext, onError }) => {
     setLoading(true);
     addPoints(value)
       .then((p) => {
-        const added = p.points - profile.points;
+        const added = points;
         const days = expirationType ? expirationDays[expirationType] ?? 0 : 0;
         const d = new Date();
         d.setDate(d.getDate() + days);


### PR DESCRIPTION
## Summary
- prorate points preview just like backend
- use calculated points when moving to final step

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:renderer` (fails: Cannot find module 'tailwindcss')

------
https://chatgpt.com/codex/tasks/task_e_68b096617f2c8328a309bd6a560d2359