### PR TITLE
feat: clean app data on uninstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
           "url": "${env.BUCKET_URL}/linux"
         }
       ]
+    },
+    "nsis": {
+      "deleteAppDataOnUninstall": true
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- ensure Windows uninstaller removes app data

## Testing
- `npm ci`
- `npm run dist:publish` *(fails: cannot expand pattern "${env.BUCKET_URL}/linux": env BUCKET_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d2d3b1b4832899e56749dc5b678c