### PR TITLE
Use relative logo paths for renderer logos

### DIFF
--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -1,4 +1,6 @@
 import React, { forwardRef } from 'react';
+import logoWhite from '../public/logo-white.png';
+import logoPrincipal from '../public/logo-principal.png';
 
 interface Props {
   onLogout: () => void;
@@ -18,7 +20,7 @@ const Header = forwardRef<HTMLDivElement, Props>(({ onLogout }, ref) => {
   }, []);
 
   // Ajusta el tamaño según el modo
-  const logoSrc = isDark ? "/logo-white.png" : "/logo-principal.png";
+  const logoSrc = isDark ? logoWhite : logoPrincipal;
   const logoClass = isDark
     ? "h-14 sm:h-24 md:h-32 w-auto"
     : "h-8 sm:h-10 md:h-12 w-auto";

--- a/src/renderer/pages/LoginUser.tsx
+++ b/src/renderer/pages/LoginUser.tsx
@@ -3,6 +3,8 @@ import { login, fetchCurrentUser, fetchBranches } from '../api/auth';
 import Spinner from '../components/Spinner';
 import Toast from '../components/Toast';
 import { useCompany } from '../context/CompanyContext';
+import logoWhite from '../public/logo-white.png';
+import logoPrincipal from '../public/logo-principal.png';
 
 interface Props {
   onLogin: () => void;
@@ -54,7 +56,7 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
     }
   };
 
-  const logoSrc = isDark ? "/logo-white.png" : "/logo-principal.png";
+  const logoSrc = isDark ? logoWhite : logoPrincipal;
 
   if (loading)
     return (


### PR DESCRIPTION
## Summary
- import logo images and use relative paths in `Header` and `LoginUser`

## Testing
- `npm run build`
- `npm run dist` *(fails: cannot expand pattern "${env.BUCKET_URL}/linux" since BUCKET_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d67c502083288dc064ea4f8f97e4