### PR TITLE
Handle invalid login credentials error

### DIFF
--- a/src/renderer/pages/LoginUser.tsx
+++ b/src/renderer/pages/LoginUser.tsx
@@ -47,6 +47,8 @@ const LoginUser: React.FC<Props> = ({ onLogin }) => {
       localStorage.removeItem('refresh_token');
       if (err instanceof Error && err.message === 'INVALID_POS') {
         setToast('El punto de venta configurado no corresponde a la empresa o está suspendido');
+      } else if (err instanceof Error && err.message === 'BAD_CREDENTIALS') {
+        setToast('Usuario o contraseña incorrectos');
       } else {
         setToast('Ocurrió un error, prueba de nuevo');
       }


### PR DESCRIPTION
## Summary
- detect invalid_grant responses during login and surface BAD_CREDENTIALS error
- show toast message for incorrect user credentials on login

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1d7a90330832897e2710f174957fe