### PR TITLE
fix updater hooks for web build

### DIFF
--- a/src/renderer/components/UpdateNotice.tsx
+++ b/src/renderer/components/UpdateNotice.tsx
@@ -6,9 +6,9 @@ const UpdateNotice: React.FC = () => {
   const [progress, setProgress] = React.useState(0)
 
   React.useEffect(() => {
-    window.awer.onUpdateAvailable(() => setAvailable(true))
-    window.awer.onDownloadProgress((p) => setProgress(p.percent))
-    window.awer.onUpdateDownloaded(() => {
+    window.awer?.onUpdateAvailable(() => setAvailable(true))
+    window.awer?.onDownloadProgress((p) => setProgress(p.percent))
+    window.awer?.onUpdateDownloaded(() => {
       setProgress(100)
       setDownloading(false)
     })
@@ -16,7 +16,7 @@ const UpdateNotice: React.FC = () => {
 
   const start = () => {
     setDownloading(true)
-    window.awer.startUpdate()
+    window.awer?.startUpdate()
   }
 
   if (!available) return null

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2,7 +2,7 @@ export {}
 
 declare global {
   interface Window {
-    awer: {
+    awer?: {
       ping: () => Promise<string>
       onUpdateAvailable: (cb: () => void) => void
       onDownloadProgress: (cb: (p: { percent: number }) => void) => void


### PR DESCRIPTION
## Summary
- guard update hooks with optional chaining to avoid web runtime errors
- mark `window.awer` optional in global typings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1da0b90ac83288510565c8adc7066